### PR TITLE
[Feature] 모집 수정, 모집 삭제, 탁구장 검색

### DIFF
--- a/src/main/java/org/ureca/pinggubackend/domain/location/controller/LocationController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/location/controller/LocationController.java
@@ -1,0 +1,23 @@
+package org.ureca.pinggubackend.domain.location.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.ureca.pinggubackend.domain.location.dto.LocationGetDto;
+import org.ureca.pinggubackend.domain.location.service.LocationService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/location")
+public class LocationController {
+
+    private final LocationService locationService;
+
+    @GetMapping("")
+    public ResponseEntity<LocationGetDto> getLocation(String gu) {
+        LocationGetDto locationGetDto = locationService.getLocations(gu);
+        return ResponseEntity.ok(locationGetDto);
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/location/dto/ClubDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/location/dto/ClubDto.java
@@ -1,0 +1,11 @@
+package org.ureca.pinggubackend.domain.location.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ClubDto {
+    Long clubId;
+    String name;
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/location/dto/LocationGetDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/location/dto/LocationGetDto.java
@@ -1,0 +1,21 @@
+package org.ureca.pinggubackend.domain.location.dto;
+
+import lombok.Getter;
+import org.ureca.pinggubackend.domain.location.entity.Club;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class LocationGetDto {
+
+    private final List<ClubDto> clubs;
+
+    public LocationGetDto(List<Club> list) {
+        List<ClubDto> clubDtos = new ArrayList<>();
+        for (Club club : list) {
+            clubDtos.add(new ClubDto(club.getId(), club.getName()));
+        }
+        this.clubs = clubDtos;
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/location/service/LocationService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/location/service/LocationService.java
@@ -1,0 +1,21 @@
+package org.ureca.pinggubackend.domain.location.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.ureca.pinggubackend.domain.location.dto.LocationGetDto;
+import org.ureca.pinggubackend.domain.location.entity.Club;
+import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final ClubRepository clubRepository;
+
+    public LocationGetDto getLocations(String gu) {
+        List<Club> clubs = clubRepository.findByGu(gu);
+        return new LocationGetDto(clubs);
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -25,21 +25,21 @@ public class RecruitController {
         return ResponseEntity.created(uri).build();
     }
 
-    @GetMapping("")
-    public ResponseEntity<RecruitGetDto> getRecruit(Long recruitId) {
+    @GetMapping("/{recruitId}")
+    public ResponseEntity<RecruitGetDto> getRecruit(@PathVariable Long recruitId) {
         RecruitGetDto recruitGetDto = recruitService.getRecruit(recruitId);
         return ResponseEntity.ok(recruitGetDto);
     }
 
-    @PutMapping("")
-    public ResponseEntity<Void> putRecruit(Long recruitId, @RequestBody RecruitPutDto recruitPutDto) {
+    @PutMapping("/{recruitId}")
+    public ResponseEntity<Void> putRecruit(@PathVariable Long recruitId, @RequestBody RecruitPutDto recruitPutDto) {
         // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
         recruitService.putRecruit(recruitId, recruitPutDto);
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("")
-    public ResponseEntity<Void> deleteMapping(Long recruitId) {
+    @DeleteMapping("/{recruitId}")
+    public ResponseEntity<Void> deleteMapping(@PathVariable Long recruitId) {
         // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
         recruitService.deleteRecruit(recruitId);
         return ResponseEntity.ok().build();

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -3,10 +3,9 @@ package org.ureca.pinggubackend.domain.recruit.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.ureca.pinggubackend.domain.member.entity.Member;
-import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
-import org.ureca.pinggubackend.domain.recruit.dto.RecruitGetDto;
-import org.ureca.pinggubackend.domain.recruit.dto.RecruitPostDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
 
 import java.net.URI;
@@ -30,5 +29,19 @@ public class RecruitController {
     public ResponseEntity<RecruitGetDto> getRecruit(Long recruitId) {
         RecruitGetDto recruitGetDto = recruitService.getRecruit(recruitId);
         return ResponseEntity.ok(recruitGetDto);
+    }
+
+    @PutMapping("")
+    public ResponseEntity<Void> putRecruit(Long recruitId, @RequestBody RecruitPutDto recruitPutDto) {
+        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
+        recruitService.putRecruit(recruitId, recruitPutDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<Void> deleteMapping(Long recruitId) {
+        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
+        recruitService.deleteRecruit(recruitId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -1,5 +1,6 @@
 package org.ureca.pinggubackend.domain.recruit.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,7 +33,7 @@ public class RecruitController {
     }
 
     @PutMapping("/{recruitId}")
-    public ResponseEntity<Void> putRecruit(@PathVariable Long recruitId, @RequestBody RecruitPutDto recruitPutDto) {
+    public ResponseEntity<Void> putRecruit(@PathVariable Long recruitId, @RequestBody @Valid RecruitPutDto recruitPutDto) {
         // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
         recruitService.putRecruit(recruitId, recruitPutDto);
         return ResponseEntity.ok().build();

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitGetDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitGetDto.java
@@ -1,4 +1,4 @@
-package org.ureca.pinggubackend.domain.recruit.dto;
+package org.ureca.pinggubackend.domain.recruit.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitPostDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitPostDto.java
@@ -1,4 +1,4 @@
-package org.ureca.pinggubackend.domain.recruit.dto;
+package org.ureca.pinggubackend.domain.recruit.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitPutDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitPutDto.java
@@ -1,0 +1,30 @@
+package org.ureca.pinggubackend.domain.recruit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
+import org.ureca.pinggubackend.domain.member.enums.Racket;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class RecruitPutDto {
+
+    private Long clubId;
+
+    private LocalDate date;
+
+    private Gender gender;
+
+    private Level level;
+
+    private Racket racket;
+
+    private String title;
+
+    private String document;
+
+    private String chatUrl;
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitPutDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitPutDto.java
@@ -1,5 +1,6 @@
 package org.ureca.pinggubackend.domain.recruit.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
@@ -12,19 +13,27 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class RecruitPutDto {
 
+    @NotNull
     private Long clubId;
 
+    @NotNull
     private LocalDate date;
 
+    @NotNull
     private Gender gender;
 
+    @NotNull
     private Level level;
 
+    @NotNull
     private Racket racket;
 
+    @NotNull
     private String title;
 
+    @NotNull
     private String document;
 
+    @NotNull
     private String chatUrl;
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/entity/Recruit.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/entity/Recruit.java
@@ -3,6 +3,7 @@ package org.ureca.pinggubackend.domain.recruit.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.ureca.pinggubackend.domain.member.entity.Member;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.global.entity.BaseEntity;
 import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
@@ -20,7 +21,6 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Builder
-@Setter
 public class Recruit extends BaseEntity {
 
     @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -68,5 +68,16 @@ public class Recruit extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean status;
+
+    public void updateRecruit(Club club, RecruitPutDto dto) {
+        this.club = club;
+        this.date = dto.getDate();
+        this.gender = dto.getGender();
+        this.level = dto.getLevel();
+        this.racket = dto.getRacket();
+        this.title = dto.getTitle();
+        this.document = dto.getDocument();
+        this.chatUrl = dto.getChatUrl();
+    }
 
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/entity/Recruit.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/entity/Recruit.java
@@ -20,6 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Builder
+@Setter
 public class Recruit extends BaseEntity {
 
     @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
@@ -1,7 +1,8 @@
 package org.ureca.pinggubackend.domain.recruit.service;
 
-import org.ureca.pinggubackend.domain.recruit.dto.RecruitGetDto;
-import org.ureca.pinggubackend.domain.recruit.dto.RecruitPostDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 
 import java.util.List;
@@ -11,5 +12,6 @@ public interface RecruitService {
     Long postRecruit(RecruitPostDto recruitPostDto);
     List<RecruitResponse> getRecruitsByMemberId(Long memberId);
     RecruitGetDto getRecruit(Long recruitId);
-
+    void putRecruit(Long recruitId, RecruitPutDto recruitPutDto);
+    void deleteRecruit(Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -93,7 +93,7 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     private RecruitGetDto mapToRecruitDto(Recruit recruit) {
-        Club club = clubRepository.findById(recruit.getId())
+        Club club = clubRepository.findById(recruit.getClub().getId())
                 .orElseThrow(() -> BaseException.of(INTERNAL_SERVER_ERROR));
 
         RecruitGetDto recruitGetDto = RecruitGetDto.builder()

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -52,7 +52,10 @@ public class RecruitServiceImpl implements RecruitService {
             throw RecruitException.of(FORBIDDEN_RECRUIT_ACCESS);
         }
 
-        updateRecruit(recruit, recruitPutDto);
+        Club club = clubRepository.findById(recruitPutDto.getClubId())
+                .orElseThrow(() -> RecruitException.of(INVALID_CLUB));
+
+        recruit.updateRecruit(club, recruitPutDto);
         recruitRepository.save(recruit);
     }
 
@@ -112,21 +115,6 @@ public class RecruitServiceImpl implements RecruitService {
                 .build();
 
         return recruitGetDto;
-    }
-
-    private void updateRecruit(Recruit recruit, RecruitPutDto recruitPutDto) {
-        Club club = clubRepository.findById(recruitPutDto.getClubId())
-                .orElseThrow(() -> RecruitException.of(INVALID_CLUB));
-
-        recruit.setClub(club);
-        recruit.setDate(recruitPutDto.getDate());
-        recruit.setGender(recruitPutDto.getGender());
-        recruit.setLevel(recruit.getLevel());
-        recruit.setRacket(recruit.getRacket());
-        recruit.setTitle(recruitPutDto.getTitle());
-        recruit.setDocument(recruit.getDocument());
-        recruit.setChatUrl(recruitPutDto.getChatUrl());
-
     }
 
     // 임시!

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -6,8 +6,9 @@ import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
-import org.ureca.pinggubackend.domain.recruit.dto.RecruitGetDto;
-import org.ureca.pinggubackend.domain.recruit.dto.RecruitPostDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
@@ -15,6 +16,7 @@ import org.ureca.pinggubackend.global.exception.BaseException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.INTERNAL_SERVER_ERROR;
 import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.INVALID_INPUT_VALUE;
@@ -39,6 +41,33 @@ public class RecruitServiceImpl implements RecruitService {
         Recruit recruit = recruitRepository.findById(recruitId)
                 .orElseThrow(() -> BaseException.of(INVALID_INPUT_VALUE));
         return mapToRecruitDto(recruit);
+    }
+
+    public void putRecruit(Long recruitId, RecruitPutDto recruitPutDto) {
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(() -> BaseException.of(INVALID_INPUT_VALUE));
+
+        // 글을 작성한 유저가 아니라면 예외 발생
+        Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
+        if (!Objects.equals(recruit.getMember().getId(), member.getId())) {
+            throw BaseException.of(INVALID_INPUT_VALUE);
+        }
+
+        updateRecruit(recruit, recruitPutDto);
+        recruitRepository.save(recruit);
+    }
+
+    public void deleteRecruit(Long recruitId) {
+        Recruit recruit = recruitRepository.findById(recruitId)
+                .orElseThrow(() -> BaseException.of(INVALID_INPUT_VALUE));
+
+        // 글을 작성한 유저가 아니라면 예외 발생
+        Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
+        if (!Objects.equals(recruit.getMember().getId(), member.getId())) {
+            throw BaseException.of(INVALID_INPUT_VALUE);
+        }
+
+        recruitRepository.deleteById(recruitId);
     }
 
     private Recruit mapToRecruit(Member member, RecruitPostDto recruitPostDto) {
@@ -84,6 +113,21 @@ public class RecruitServiceImpl implements RecruitService {
                 .build();
 
         return recruitGetDto;
+    }
+
+    private void updateRecruit(Recruit recruit, RecruitPutDto recruitPutDto) {
+        Club club = clubRepository.findById(recruitPutDto.getClubId())
+                        .orElseThrow(() -> BaseException.of(INVALID_INPUT_VALUE));
+
+        recruit.setClub(club);
+        recruit.setDate(recruitPutDto.getDate());
+        recruit.setGender(recruitPutDto.getGender());
+        recruit.setLevel(recruit.getLevel());
+        recruit.setRacket(recruit.getRacket());
+        recruit.setTitle(recruitPutDto.getTitle());
+        recruit.setDocument(recruit.getDocument());
+        recruit.setChatUrl(recruitPutDto.getChatUrl());
+
     }
 
     // 임시!

--- a/src/main/java/org/ureca/pinggubackend/global/exception/recruit/RecruitErrorCode.java
+++ b/src/main/java/org/ureca/pinggubackend/global/exception/recruit/RecruitErrorCode.java
@@ -1,0 +1,24 @@
+package org.ureca.pinggubackend.global.exception.recruit;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.ureca.pinggubackend.global.exception.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum RecruitErrorCode implements ErrorCode {
+    INVALID_CLUB(HttpStatus.BAD_REQUEST, "001", "올바르지 않은 탁구장입니다."),
+    RECRUIT_NOT_FOUND(HttpStatus.NOT_FOUND, "002", "존재하지 않는 모집입니다."),
+    FORBIDDEN_RECRUIT_ACCESS(HttpStatus.FORBIDDEN, "003", "수정 권한이 없습니다.");
+
+    private static final String PREFIX = "RECRUIT";
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public String getFullCode() {
+        return PREFIX + "_" + code;
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/global/exception/recruit/RecruitException.java
+++ b/src/main/java/org/ureca/pinggubackend/global/exception/recruit/RecruitException.java
@@ -1,0 +1,15 @@
+package org.ureca.pinggubackend.global.exception.recruit;
+
+import org.ureca.pinggubackend.global.exception.BaseException;
+import org.ureca.pinggubackend.global.exception.ErrorCode;
+
+public class RecruitException extends BaseException {
+
+    protected RecruitException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static RecruitException of(RecruitErrorCode recruitErrorCode) {
+        return new RecruitException(recruitErrorCode);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#16 

## 📝 요약(Summary)
모집을 수정하고 삭제하는 기능, 탁구장을 검색하는 기능을 개발했습니다. 그 과정에서 모집 조회 기능의 버그를 수정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
1. 예외는 도메인 디렉터리가 아닌 글로벌에 두었습니다. 더 좋은 구조가 있다면 알려주세요!
2. 모집 조회 기능 중 탁구장 조회 중 오류가 있었던 것을 수정했습니다.
3. 수정과 삭제는 유저가 작성한 글이 맞는지 검증하는 로직이 필요합니다. 아직 로그인이 구현되지 않았으므로, 임시로 처리해두었습니다. 로그인 개발이 완료되면 적용하겠습니다.
4. 탁구장 검색은 엔티티를 그냥 던지지 않고 일급 컬렉션을 만들어서 리턴합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 15분
