### PR TITLE
feature: 마이페이지 지원현황, 좋아요별 모집, 작성한 모집 api 개발

### DIFF
--- a/src/main/java/org/ureca/pinggubackend/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/repository/ApplyRepository.java
@@ -3,5 +3,9 @@ package org.ureca.pinggubackend.domain.apply.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.ureca.pinggubackend.domain.apply.entity.Apply;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
+    List<Apply> findByMemberId(Long memberId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyService.java
@@ -1,9 +1,10 @@
 package org.ureca.pinggubackend.domain.apply.service;
 
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 
 import java.util.List;
 
 public interface ApplyService {
-    List<RecruitResponse> getLikesByMemberId(Long memberId);
+    List<MyApplyResponse> getApplyListByMemberId(Long memberId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyServiceImpl.java
@@ -1,0 +1,32 @@
+package org.ureca.pinggubackend.domain.apply.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.ureca.pinggubackend.domain.apply.entity.Apply;
+import org.ureca.pinggubackend.domain.apply.repository.ApplyRepository;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
+import org.ureca.pinggubackend.global.exception.BaseException;
+import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class ApplyServiceImpl implements ApplyService{
+
+    private final ApplyRepository applyRepository;
+
+    @Override
+    public List<MyApplyResponse> getApplyListByMemberId(Long memberId) {
+
+        List<Apply> applies = applyRepository.findByMemberId(memberId);
+
+        return applies.stream()
+                .map(apply -> MyApplyResponse.from(apply.getRecruit()))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeService.java
@@ -1,9 +1,10 @@
 package org.ureca.pinggubackend.domain.likes.service;
 
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 
 import java.util.List;
 
 public interface LikeService {
-    List<RecruitResponse> getLikesByMemberId(Long memberId);
+    List<MyLikeResponse> getLikeListByMemberId(Long memberId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeServiceImpl.java
@@ -1,0 +1,32 @@
+package org.ureca.pinggubackend.domain.likes.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.ureca.pinggubackend.domain.likes.entity.Likes;
+import org.ureca.pinggubackend.domain.likes.repository.LikeRepository;
+import org.ureca.pinggubackend.domain.member.entity.Member;
+import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
+import org.ureca.pinggubackend.global.exception.BaseException;
+import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class LikeServiceImpl implements LikeService {
+
+    private final LikeRepository likeRepository;
+
+    @Override
+    public List<MyLikeResponse> getLikeListByMemberId(Long memberId) {
+        List<Likes> myLikes = likeRepository.findByMemberId(memberId);
+
+        return myLikes.stream()
+                .map(like -> MyLikeResponse.from(like.getRecruit()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/member/enums/Racket.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/enums/Racket.java
@@ -1,6 +1,6 @@
 package org.ureca.pinggubackend.domain.member.enums;
 
 public enum Racket {
-    SHACK_HAND,
+    SHAKE_HAND,
     PEN_HOLDER
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
@@ -1,14 +1,19 @@
 package org.ureca.pinggubackend.domain.mypage.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.Get;
+import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.ureca.pinggubackend.domain.apply.service.ApplyService;
 import org.ureca.pinggubackend.domain.likes.service.LikeService;
 import org.ureca.pinggubackend.domain.member.service.MemberService;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyProfileResponse;
 import org.ureca.pinggubackend.domain.mypage.dto.request.MyProfileUpdate;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.mypage.service.MyPageService;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
@@ -17,13 +22,9 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/me")
+@RequestMapping("/mypage")
 public class MyPageController {
 
-//    private final RecruitService recruitService;
-//    private final ApplyService applyService;
-//    private final LikeService likeService;
-//    private final MemberService memberService;
     private final MyPageService myPageService;
 
     /**
@@ -36,46 +37,24 @@ public class MyPageController {
         return ResponseEntity.ok(myPageResponse);
     }
 
-//    /**
-//     * @param memberId
-//     * @return 내가 올린 모집(들)
-//     */
-//    @GetMapping("/my-recruit")
-//    public ResponseEntity<List<RecruitResponse>> getMyRecruits(@AuthenticationPrincipal Long memberId) {
-//        List<RecruitResponse> myRecruits = recruitService.getRecruitsByMemberId(memberId);
-//        return ResponseEntity.ok(myRecruits);
-//    }
-//
-//    /**
-//     * @param memberId
-//     * @return 내가 지원한 모집(들)
-//     */
-//    @GetMapping("/apply-list")
-//    public ResponseEntity<List<RecruitResponse>> getMyLikes(@AuthenticationPrincipal Long memberId) {
-//        List<RecruitResponse> myApplies = applyService.getLikesByMemberId(memberId);
-//        return ResponseEntity.ok(myApplies);
-//    }
-//
-//    /**
-//     * @param memberId
-//     * @return 내가 좋아요한 모집(들)
-//     */
-//    @GetMapping("/likes")
-//    public ResponseEntity<List<RecruitResponse>> getMyLikes(@AuthenticationPrincipal Long memberId) {
-//        List<RecruitResponse> myLikes = likeService.getLikesByMemberId(memberId);
-//        return ResponseEntity.ok(myLikes);
-//    }
-//
-//    /**
-//     * @param memberId
-//     * @param request
-//     * @return 내 프로필 수정
-//     */
-//    @PutMapping("/profile")
-//    public ResponseEntity<MyProfileResponse> updateProfile(@AuthenticationPrincipal Long memberId, @RequestBody MyProfileUpdate request) {
-//        MyProfileResponse memberProfile = memberService.updateMyProfile(memberId, request);
-//        return ResponseEntity.ok(memberProfile);
-//    }
+    @GetMapping("/applies")
+    public ResponseEntity<List<MyApplyResponse>> getMyApplies(@RequestParam Long memberId) {
+        List<MyApplyResponse> response = myPageService.getMyApplies(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/likes")
+    public ResponseEntity<List<MyLikeResponse>> getMyLikes(@RequestParam Long memberId) {
+        List<MyLikeResponse> response = myPageService.getMyLikes(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/recruits")
+    public ResponseEntity<List<MyRecruitResponse>> getMyRecruits(@RequestParam Long memberId) {
+        List<MyRecruitResponse> response = myPageService.getMyRecruits(memberId);
+        return ResponseEntity.ok(response);
+    }
+
 
     // TODO: 내 좋아요 취소, 내 신청 취소 -> 해당 게시글 상세 조회 시, 해당 게시글의 좋아요, 신청에 내가 있을 때 삭제 / 없을 때 신청
     // -> RecruitController 에서 하기

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyApplyResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyApplyResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Getter
@@ -14,13 +15,8 @@ public class MyApplyResponse {
     private final String title;
     private final List<String> club;
     private final String date;
-    private final Integer capacity;
-    private final Integer current;
-    private final String gender;
-    private final String level;
-    private final String racket;
-    private final String document;
     private final String chatUrl;
+    private final String status;
 
 
     public static MyApplyResponse from(Recruit recruit) {
@@ -28,14 +24,9 @@ public class MyApplyResponse {
                 recruit.getId(),
                 recruit.getTitle(),
                 List.of(recruit.getClub().getName(), recruit.getClub().getAddress()),
-                recruit.getClub().getGu(),
-                recruit.getCapacity(),
-                recruit.getCurrent(),
-                recruit.getGender().toString(),
-                recruit.getLevel().toString(),
-                recruit.getRacket().toString(),
-                recruit.getDocument(),
-                recruit.getChatUrl()
+                recruit.getDate().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")),
+                recruit.getChatUrl(),
+                recruit.getStatus() ? "모집 진행중" : "모집 종료"
         );
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyLikeResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyLikeResponse.java
@@ -1,0 +1,24 @@
+package org.ureca.pinggubackend.domain.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MyLikeResponse {
+    private final Long id;
+    private final String title;
+    private final String date;
+
+    public static MyLikeResponse from(Recruit recruit) {
+        return new MyLikeResponse(
+                recruit.getId(),
+                recruit.getTitle(),
+                recruit.getDate().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"))
+        );
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyRecruitResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyRecruitResponse.java
@@ -1,0 +1,23 @@
+package org.ureca.pinggubackend.domain.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@AllArgsConstructor
+public class MyRecruitResponse {
+    private final Long id;
+    private final String title;
+    private final String date;
+
+    public static MyRecruitResponse from(Recruit recruit) {
+        return new MyRecruitResponse(
+                recruit.getId(),
+                recruit.getTitle(),
+                recruit.getDate().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"))
+        );
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageService.java
@@ -2,19 +2,48 @@ package org.ureca.pinggubackend.domain.mypage.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.ureca.pinggubackend.domain.apply.service.ApplyService;
+import org.ureca.pinggubackend.domain.likes.service.LikeService;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyProfileResponse;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
+import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
+import org.ureca.pinggubackend.global.exception.BaseException;
+
+import java.util.List;
+
+import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
 
     private final MemberRepository memberRepository;
+    private final RecruitService recruitService;
+    private final ApplyService applyService;
+    private final LikeService likeService;
 
     //TODO: 멤버 관련 커스템 예외 정의되면 해당 예외 수정
     public MyProfileResponse getMyPageInfo(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(()->new IllegalArgumentException("아따 사람이없당께"));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> BaseException.of(USER_NOT_FOUND));
         return MyProfileResponse.from(member);
     }
+
+    public List<MyApplyResponse> getMyApplies(Long memberId) {
+        return applyService.getApplyListByMemberId(memberId);
+    }
+
+    public List<MyLikeResponse> getMyLikes(Long memberId) {
+        return likeService.getLikeListByMemberId(memberId);
+    }
+
+    public List<MyRecruitResponse> getMyRecruits(Long memberId) {
+        return recruitService.getRecruitListByMemberId(memberId);
+    }
+
+
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
@@ -1,8 +1,13 @@
 package org.ureca.pinggubackend.domain.recruit.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface RecruitRepository extends JpaRepository<Recruit, Long> {
 
+    List<Recruit> findByMemberId(Long memberId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
@@ -1,5 +1,6 @@
 package org.ureca.pinggubackend.domain.recruit.service;
 
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
@@ -9,7 +10,6 @@ import java.util.List;
 public interface RecruitService {
 
     Long postRecruit(RecruitPostDto recruitPostDto);
-    List<RecruitResponse> getRecruitsByMemberId(Long memberId);
+    List<MyRecruitResponse> getRecruitListByMemberId(Long memberId);
     RecruitGetDto getRecruit(Long recruitId);
-
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -1,11 +1,13 @@
 package org.ureca.pinggubackend.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
@@ -15,9 +17,9 @@ import org.ureca.pinggubackend.global.exception.BaseException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.INTERNAL_SERVER_ERROR;
-import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.INVALID_INPUT_VALUE;
+import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -86,9 +88,12 @@ public class RecruitServiceImpl implements RecruitService {
         return recruitGetDto;
     }
 
-    // 임시!
-    public List<RecruitResponse> getRecruitsByMemberId(Long memberId) {
-        return new ArrayList<>();
-    }
+    @Override
+    public List<MyRecruitResponse> getRecruitListByMemberId(Long memberId) {
+        List<Recruit> recruits = recruitRepository.findByMemberId(memberId);
 
+        return recruits.stream()
+                .map(recruit -> MyRecruitResponse.from(recruit))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/ureca/pinggubackend/global/exception/common/CommonErrorCode.java
+++ b/src/main/java/org/ureca/pinggubackend/global/exception/common/CommonErrorCode.java
@@ -10,7 +10,8 @@ import org.ureca.pinggubackend.global.exception.ErrorCode;
 public enum CommonErrorCode implements ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "001", "잘못된 입력값입니다."),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "002", "잘못된 타입입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "내부 서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "내부 서버 오류가 발생했습니다."),
+    USER_NOT_FOUND(HttpStatus.FORBIDDEN,"403","존재하지 않은 사용자입니다.");
 
     private static final String PREFIX = "COMMON";
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣ Issue Number

 #19 

## 📝 요약(Summary)

- 마이페이지에서 아래 세 가지 모집글 목록을 조회하는 기능을 구현했습니다:  
  1. 내가 지원한 모집글  
  2. 좋아요한 모집글  
  3. 내가 올린 모집글  
- 기존 컨트롤러에서 주석 처리되었던 코드들을 정리하고, MyPageService 중심으로 로직을 구성하였습니다.

## 🛠️ PR 유형
- [x] 기능 추가  

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 각 조회 기능마다 필요한 DTO 및 ServiceImpl을 분리하여 명확히 구성하였습니다.  
- 불필요한 주석 및 중복 코드를 제거했습니다.  
- 응답 형태와 구조가 괜찮은지, 서비스/컨트롤러의 역할 분리가 잘 되었는지 확인 부탁드립니다.


## ✅ PR Checklist

- [x] 테스트 코드 작성 또는 기존 테스트 통과 확인  
- [x] 기능 요구사항에 맞는 구현  

## 🤔 Review 예상 시간
- 10분 이내
