### PR TITLE
feat: 메인화면 모집 필터링 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
 	// liquibase
 	implementation("org.liquibase:liquibase-core:4.29.0")
 
+	// queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ureca/pinggubackend/domain/member/enums/Gender.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/enums/Gender.java
@@ -2,5 +2,6 @@ package org.ureca.pinggubackend.domain.member.enums;
 
 public enum Gender {
     M,
-    F
+    F,
+    ALL
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -2,6 +2,9 @@ package org.ureca.pinggubackend.domain.recruit.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
@@ -14,7 +17,6 @@ import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
 
 import java.net.URI;
 import java.time.LocalDate;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,13 +26,16 @@ public class RecruitController {
     private final RecruitService recruitService;
 
     @GetMapping
-    public ResponseEntity<List<RecruitPreviewListResponse>> getFilteredRecruits(
+    public ResponseEntity<Page<RecruitPreviewListResponse>> getFilteredRecruits(
             @RequestParam(required = false) LocalDate date,
             @RequestParam(required = false) String gu,
             @RequestParam(required = false) Level level,
-            @RequestParam(required = false) Gender gender
+            @RequestParam(required = false) Gender gender,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ){
-        List<RecruitPreviewListResponse> result = recruitService.getRecruitPreviewList(date,gu,level,gender);
+        Pageable pageable = PageRequest.of(page,size);
+        Page<RecruitPreviewListResponse> result = recruitService.getRecruitPreviewList(date,gu,level,gender,pageable);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -4,12 +4,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
 
 import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,6 +22,17 @@ import java.net.URI;
 public class RecruitController {
 
     private final RecruitService recruitService;
+
+    @GetMapping
+    public ResponseEntity<List<RecruitPreviewListResponse>> getFilteredRecruits(
+            @RequestParam(required = false) LocalDate date,
+            @RequestParam(required = false) String gu,
+            @RequestParam(required = false) Level level,
+            @RequestParam(required = false) Gender gender
+    ){
+        List<RecruitPreviewListResponse> result = recruitService.getRecruitPreviewList(date,gu,level,gender);
+        return ResponseEntity.ok(result);
+    }
 
     @PostMapping("")
     public ResponseEntity<Void> postRecruit(@RequestBody RecruitPostDto recruitPostDto) {

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/response/RecruitPreviewListResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/response/RecruitPreviewListResponse.java
@@ -1,0 +1,16 @@
+package org.ureca.pinggubackend.domain.recruit.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class RecruitPreviewListResponse {
+    private final String clubName;
+    private final LocalDate date;
+    private final String title;
+    private final Integer capacity;
+    private final Integer current;
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
@@ -2,12 +2,15 @@ package org.ureca.pinggubackend.domain.recruit.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.ureca.pinggubackend.domain.member.entity.Member;
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface RecruitRepository extends JpaRepository<Recruit, Long> {
-
     List<Recruit> findByMemberId(Long memberId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustom.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustom.java
@@ -1,0 +1,12 @@
+package org.ureca.pinggubackend.domain.recruit.repository;
+
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RecruitRepositoryCustom {
+    List<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender);
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustom.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustom.java
@@ -1,12 +1,13 @@
 package org.ureca.pinggubackend.domain.recruit.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public interface RecruitRepositoryCustom {
-    List<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender);
+    Page<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender, Pageable pageable);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustomImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package org.ureca.pinggubackend.domain.recruit.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.ureca.pinggubackend.domain.location.entity.QClub;
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
+import org.ureca.pinggubackend.domain.recruit.entity.QRecruit;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitRepositoryCustomImpl implements RecruitRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender) {
+        QRecruit recruit = QRecruit.recruit;
+        QClub club = QClub.club;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        RecruitPreviewListResponse.class,
+                        club.name,            // clubName
+                        recruit.date,
+                        recruit.title,
+                        recruit.capacity,
+                        recruit.current
+                ))
+                .from(recruit)
+                .join(recruit.club, club)
+                .where(
+                        date != null ? recruit.date.eq(date) : null,
+                        gu != null ? club.gu.eq(gu) : null,
+                        level != null ? recruit.level.eq(level) : null,
+                        gender != null ? recruit.gender.eq(gender) : null
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustomImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepositoryCustomImpl.java
@@ -1,8 +1,12 @@
 package org.ureca.pinggubackend.domain.recruit.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.ureca.pinggubackend.domain.location.entity.QClub;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
@@ -19,14 +23,20 @@ public class RecruitRepositoryCustomImpl implements RecruitRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender) {
+    public Page<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender, Pageable pageable) {
         QRecruit recruit = QRecruit.recruit;
         QClub club = QClub.club;
 
-        return queryFactory
+        BooleanBuilder builder = new BooleanBuilder();
+        if (date != null) builder.and(recruit.date.eq(date));
+        if (gu != null) builder.and(club.gu.eq(gu));
+        if (level != null) builder.and(recruit.level.eq(level));
+        if (gender != null) builder.and(recruit.gender.eq(gender));
+
+        List<RecruitPreviewListResponse> content = queryFactory
                 .select(Projections.constructor(
                         RecruitPreviewListResponse.class,
-                        club.name,            // clubName
+                        club.name,
                         recruit.date,
                         recruit.title,
                         recruit.capacity,
@@ -34,12 +44,19 @@ public class RecruitRepositoryCustomImpl implements RecruitRepositoryCustom {
                 ))
                 .from(recruit)
                 .join(recruit.club, club)
-                .where(
-                        date != null ? recruit.date.eq(date) : null,
-                        gu != null ? club.gu.eq(gu) : null,
-                        level != null ? recruit.level.eq(level) : null,
-                        gender != null ? recruit.gender.eq(gender) : null
-                )
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        long count = queryFactory
+                .select(recruit.count())
+                .from(recruit)
+                .join(recruit.club, club)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count);
     }
+
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
@@ -1,10 +1,14 @@
 package org.ureca.pinggubackend.domain.recruit.service;
 
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface RecruitService {
@@ -14,4 +18,5 @@ public interface RecruitService {
     RecruitGetDto getRecruit(Long recruitId);
     void putRecruit(Long recruitId, RecruitPutDto recruitPutDto);
     void deleteRecruit(Long recruitId);
+    List<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
@@ -1,11 +1,13 @@
 package org.ureca.pinggubackend.domain.recruit.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 
 import java.time.LocalDate;
@@ -18,5 +20,5 @@ public interface RecruitService {
     RecruitGetDto getRecruit(Long recruitId);
     void putRecruit(Long recruitId, RecruitPutDto recruitPutDto);
     void deleteRecruit(Long recruitId);
-    List<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender);
+    Page<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender, Pageable pageable);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -1,6 +1,8 @@
 package org.ureca.pinggubackend.domain.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
@@ -8,11 +10,10 @@ import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
-
+import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
@@ -22,9 +23,9 @@ import org.ureca.pinggubackend.global.exception.recruit.RecruitException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
-import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.*;
-
 import java.util.stream.Collectors;
+
+import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -80,13 +81,14 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     @Override
-    public List<RecruitPreviewListResponse> getRecruitPreviewList(
+    public Page<RecruitPreviewListResponse> getRecruitPreviewList(
             LocalDate date,
             String gu,
             Level level,
-            Gender gender
+            Gender gender,
+            Pageable pageable
     ) {
-        return recruitRepositoryCustom.getRecruitPreviewList(date, gu, level, gender);
+        return recruitRepositoryCustom.getRecruitPreviewList(date, gu, level, gender,pageable);
     }
 
     private Recruit mapToRecruit(Member member, RecruitPostDto recruitPostDto) {

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -5,16 +5,21 @@ import org.springframework.stereotype.Service;
 import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
 import org.ureca.pinggubackend.domain.member.entity.Member;
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
 
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
+import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
+import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepositoryCustom;
 import org.ureca.pinggubackend.global.exception.recruit.RecruitException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.*;
@@ -28,6 +33,7 @@ public class RecruitServiceImpl implements RecruitService {
     private final ClubRepository clubRepository;
     private final RecruitRepository recruitRepository;
     private final MemberRepository memberRepository;
+    private final RecruitRepositoryCustom recruitRepositoryCustom;
 
     public Long postRecruit(RecruitPostDto recruitPostDto) {
         Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
@@ -71,6 +77,16 @@ public class RecruitServiceImpl implements RecruitService {
         }
 
         recruitRepository.deleteById(recruitId);
+    }
+
+    @Override
+    public List<RecruitPreviewListResponse> getRecruitPreviewList(
+            LocalDate date,
+            String gu,
+            Level level,
+            Gender gender
+    ) {
+        return recruitRepositoryCustom.getRecruitPreviewList(date, gu, level, gender);
     }
 
     private Recruit mapToRecruit(Member member, RecruitPostDto recruitPostDto) {

--- a/src/main/java/org/ureca/pinggubackend/global/config/QueryDslConfig.java
+++ b/src/main/java/org/ureca/pinggubackend/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.ureca.pinggubackend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#23 

## 📝 요약(Summary)

- QueryDsl을 이용해서 필터링을 구현했습니다.
- Gender에 성별무관에 해당하는 "ALL" 추가
- QueryDsl을 이용하기 위한 의존성과 설정 파일 코드 및 RecruitRepositoryCustom 생성

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 파일 수정

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/7b574ea8-a2c2-4407-a90a-7fdf697cac4b)
- QueryDsl 사용을 위해 build.gradle에 의존성 추가

![image](https://github.com/user-attachments/assets/44fb7232-39e4-4ed7-8a71-130fd7200427)
- QueryDsl 설정 코드 추가

![image](https://github.com/user-attachments/assets/91b50b9c-383d-4333-9ab1-25a39e96d2bf)
- QueryDsl 사용을 위한 RecruitRepositoryCustom 인터페이스및 Impl 추가

![image](https://github.com/user-attachments/assets/c590f578-0b74-4c4b-abce-3b7f43ea6c0e)
- 검색 필터링 엔드 포인트 추가



## 💬 공유사항 to 리뷰어

- 스크린샷에 언급되어 있는 내용을 잘 봐주시면 감사하겠습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 15분
