### PR TITLE
[feature] 좋아요 및 신청 api 개발, 모집글 소프트 딜리트 기능, 엔티티 인덱스 설정

### DIFF
--- a/src/main/java/org/ureca/pinggubackend/PingGuBackendApplication.java
+++ b/src/main/java/org/ureca/pinggubackend/PingGuBackendApplication.java
@@ -2,8 +2,10 @@ package org.ureca.pinggubackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PingGuBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/ureca/pinggubackend/domain/apply/entity/Apply.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/entity/Apply.java
@@ -4,14 +4,17 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.ureca.pinggubackend.global.entity.BaseEntity;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.global.entity.BaseEntity;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Table(name = "apply", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "recruit_id"})
+})
 public class Apply extends BaseEntity {
 
     @ManyToOne

--- a/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface ApplyService {
     List<MyApplyResponse> getMyApplies(Long memberId);
     void cancelApply(Long memberId, Long recruitId);
+    void proceedApply(Long memberId, Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyServiceImpl.java
@@ -5,7 +5,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.ureca.pinggubackend.domain.apply.entity.Apply;
 import org.ureca.pinggubackend.domain.apply.repository.ApplyRepository;
+import org.ureca.pinggubackend.domain.member.entity.Member;
+import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
+import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
 import org.ureca.pinggubackend.global.exception.BaseException;
 import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
 
@@ -13,12 +17,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
+import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.RECRUIT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class ApplyServiceImpl implements ApplyService{
 
     private final ApplyRepository applyRepository;
+    private final MemberRepository memberRepository;
+    private final RecruitRepository recruitRepository;
 
     @Override
     public List<MyApplyResponse> getMyApplies(Long memberId) {
@@ -38,5 +45,17 @@ public class ApplyServiceImpl implements ApplyService{
                 .orElseThrow(() -> BaseException.of(CommonErrorCode.APPLY_NOT_FOUND));
 
         applyRepository.delete(apply);
+    }
+
+    @Override
+    @Transactional
+    public void proceedApply(Long memberId, Long recruitId) {
+        //TODO : 사용자 정보 있을 경우, memberId 수정
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> BaseException.of(USER_NOT_FOUND));
+        Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(() -> BaseException.of(RECRUIT_NOT_FOUND));
+
+        Apply apply = new Apply(member, recruit);
+
+        applyRepository.save(apply);
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/entity/Likes.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/entity/Likes.java
@@ -4,14 +4,17 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.ureca.pinggubackend.global.entity.BaseEntity;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.global.entity.BaseEntity;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Table(name = "likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "recruit_id"})
+})
 public class Likes extends BaseEntity {
 
     @ManyToOne

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface LikeService {
     List<MyLikeResponse> getLikedRecruitList(Long memberId);
+    boolean toggleLike(Long memberId, Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeServiceImpl.java
@@ -2,24 +2,31 @@ package org.ureca.pinggubackend.domain.likes.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.ureca.pinggubackend.domain.likes.entity.Likes;
 import org.ureca.pinggubackend.domain.likes.repository.LikeRepository;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
+import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
 import org.ureca.pinggubackend.global.exception.BaseException;
-import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
+import org.ureca.pinggubackend.global.exception.recruit.RecruitException;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
+import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.RECRUIT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class LikeServiceImpl implements LikeService {
 
     private final LikeRepository likeRepository;
+    private final MemberRepository memberRepository;
+    private final RecruitRepository recruitRepository;
 
     @Override
     public List<MyLikeResponse> getLikedRecruitList(Long memberId) {
@@ -28,5 +35,25 @@ public class LikeServiceImpl implements LikeService {
         return myLikes.stream()
                 .map(like -> MyLikeResponse.from(like.getRecruit()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public boolean toggleLike(Long recruitId, Long memberId) {
+        // 기존 좋아요 확인
+        Optional<Likes> existingLike = likeRepository.findByMemberIdAndRecruitId(memberId, recruitId);
+
+        if (existingLike.isPresent()) {
+            likeRepository.delete(existingLike.get());
+            return false;
+        } else {
+            Member member = memberRepository.findById(memberId).orElseThrow(() -> BaseException.of(USER_NOT_FOUND));
+            Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(() -> RecruitException.of(RECRUIT_NOT_FOUND));
+
+            Likes like = new Likes(member, recruit);
+
+            likeRepository.save(like);
+            return true;
+        }
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
@@ -13,7 +13,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/mypage")
 public class MyPageController {
-  
+
     private final MyPageService myPageService;
 
     @GetMapping
@@ -30,7 +30,7 @@ public class MyPageController {
     ){
         return ResponseEntity.ok(myPageService.editProfile(memberId,request));
     }
-  
+
     @DeleteMapping
     public ResponseEntity<MyPageDeleteResponse> deleteMember(
             @RequestParam long memberId // TODO - JWT 구현 이후 변경 예정

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyApplyResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyApplyResponse.java
@@ -2,7 +2,6 @@ package org.ureca.pinggubackend.domain.mypage.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 
 import java.time.format.DateTimeFormatter;
@@ -26,7 +25,7 @@ public class MyApplyResponse {
                 List.of(recruit.getClub().getName(), recruit.getClub().getAddress()),
                 recruit.getDate().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")),
                 recruit.getChatUrl(),
-                recruit.getStatus() ? "모집 진행중" : "모집 종료"
+                recruit.getStatus().toString()
         );
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -12,6 +12,7 @@ import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
+import org.ureca.pinggubackend.domain.recruit.dto.response.ApplyResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
 
@@ -65,5 +66,26 @@ public class RecruitController {
         // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
         recruitService.deleteRecruit(recruitId);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{recruitId}/like")
+    public ResponseEntity<Boolean> toggleLike(@PathVariable Long recruitId, @RequestParam Long memberId) {
+        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
+        boolean isLiked = recruitService.toggleLike(memberId, recruitId);
+        return ResponseEntity.ok(isLiked);
+    }
+
+    @PostMapping("/{recruitId}/apply")
+    public ResponseEntity<ApplyResponse> proceedApply(@PathVariable Long recruitId, @RequestParam Long memberId) {
+        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
+        return ResponseEntity.ok(recruitService.proceedApply(memberId, recruitId));
+    }
+
+    @DeleteMapping("/{recruitId}/apply")
+    public ResponseEntity<ApplyResponse> cancelApply(@PathVariable Long recruitId,
+                                               @RequestParam Long memberId
+    ) {
+        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
+        return ResponseEntity.ok(recruitService.cancelApply(memberId, recruitId));
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitGetDto.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/request/RecruitGetDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.member.enums.Racket;
+import org.ureca.pinggubackend.domain.recruit.enums.RecruitStatus;
 
 import java.time.LocalDate;
 
@@ -36,5 +37,5 @@ public class RecruitGetDto {
 
     private String chatUrl;
 
-    private Boolean status;
+    private RecruitStatus status;
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/response/ApplyResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/response/ApplyResponse.java
@@ -1,0 +1,11 @@
+package org.ureca.pinggubackend.domain.recruit.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApplyResponse {
+    private final Long memberId;
+    private final Long recruitId;
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/response/RecruitResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/dto/response/RecruitResponse.java
@@ -1,12 +1,9 @@
 package org.ureca.pinggubackend.domain.recruit.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Getter

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/entity/Recruit.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/entity/Recruit.java
@@ -1,31 +1,42 @@
 package org.ureca.pinggubackend.domain.recruit.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-import org.ureca.pinggubackend.domain.member.entity.Member;
-import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
-import org.ureca.pinggubackend.global.entity.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.ureca.pinggubackend.domain.apply.entity.Apply;
+import org.ureca.pinggubackend.domain.likes.entity.Likes;
 import org.ureca.pinggubackend.domain.location.entity.Club;
+import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.member.enums.Racket;
-import org.ureca.pinggubackend.domain.apply.entity.Apply;
-import org.ureca.pinggubackend.domain.likes.entity.Likes;
+import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
+import org.ureca.pinggubackend.domain.recruit.enums.RecruitStatus;
+import org.ureca.pinggubackend.global.entity.BaseEntity;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(
+        indexes = {
+                  @Index(name = "idx_status_date", columnList = "status, date"),
+                  @Index(name = "idx_recruit_status_delete_date", columnList = "status, deleteDate")
+         })
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Builder
 public class Recruit extends BaseEntity {
 
+    @Builder.Default
     @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Likes> likesList = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Apply> applies = new ArrayList<>();
 
@@ -66,8 +77,11 @@ public class Recruit extends BaseEntity {
     @Column(nullable = false)
     private String chatUrl;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Boolean status;
+    private RecruitStatus status;
+
+    private LocalDate deleteDate;
 
     public void updateRecruit(Club club, RecruitPutDto dto) {
         this.club = club;
@@ -78,6 +92,20 @@ public class Recruit extends BaseEntity {
         this.title = dto.getTitle();
         this.document = dto.getDocument();
         this.chatUrl = dto.getChatUrl();
+    }
+
+    public void closeRecruit() {
+        this.status = RecruitStatus.CLOSED;
+        this.deleteDate = LocalDate.now();
+    }
+
+    public void expireRecruit() {
+        this.status = RecruitStatus.EXPIRED;
+        this.deleteDate = LocalDate.now();
+    }
+
+    public void markAsFull() {
+        this.status = RecruitStatus.FULL;
     }
 
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/enums/RecruitStatus.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/enums/RecruitStatus.java
@@ -1,0 +1,8 @@
+package org.ureca.pinggubackend.domain.recruit.enums;
+
+public enum RecruitStatus {
+    OPEN, // 모집 중
+    FULL, // 모집 완료
+    CLOSED, // 작성자가 직접 모집 삭제
+    EXPIRED // 모집 만료
+}

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
@@ -26,4 +26,6 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
     List<Recruit> findByStatusInAndDeleteDateBefore(List<RecruitStatus> status, LocalDate thirtyDaysAgo);
 
     Integer countByStatus(RecruitStatus recruitStatus);
+
+    List<Recruit> findByMemberIdAndDeleteDateIsNull(Long memberId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/repository/RecruitRepository.java
@@ -1,16 +1,29 @@
 package org.ureca.pinggubackend.domain.recruit.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.ureca.pinggubackend.domain.member.entity.Member;
-import org.ureca.pinggubackend.domain.member.enums.Gender;
-import org.ureca.pinggubackend.domain.member.enums.Level;
-import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.domain.recruit.enums.RecruitStatus;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface RecruitRepository extends JpaRepository<Recruit, Long> {
     List<Recruit> findByMemberId(Long memberId);
+
+    /**
+     * SELECT r.*
+     * FROM recruit r
+     * WHERE r.status IN ('OPEN', 'FULL')
+     *      AND r.date < today
+     */
+    List<Recruit> findByStatusInAndDateBefore(List<RecruitStatus> status, LocalDate dateTime);
+    /**
+     * SELECT r.*
+     FROM recruit r
+     WHERE r.status IN ('EXPIRED', 'CLOSED', 'FULL')
+     AND r.delete_date < '2025-04-13 00:00:00'
+     * */
+    List<Recruit> findByStatusInAndDeleteDateBefore(List<RecruitStatus> status, LocalDate thirtyDaysAgo);
+
+    Integer countByStatus(RecruitStatus recruitStatus);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
@@ -8,6 +8,7 @@ import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
+import org.ureca.pinggubackend.domain.recruit.dto.response.ApplyResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 
 import java.time.LocalDate;
@@ -21,4 +22,7 @@ public interface RecruitService {
     void putRecruit(Long recruitId, RecruitPutDto recruitPutDto);
     void deleteRecruit(Long recruitId);
     Page<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender, Pageable pageable);
+    boolean toggleLike(Long memberId, Long recruitId);
+    ApplyResponse proceedApply(Long memberId, Long recruitId);
+    ApplyResponse cancelApply(Long memberId, Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -3,7 +3,9 @@ package org.ureca.pinggubackend.domain.recruit.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.ureca.pinggubackend.domain.apply.service.ApplyService;
 import org.ureca.pinggubackend.domain.likes.service.LikeService;
 import org.ureca.pinggubackend.domain.location.entity.Club;
@@ -19,11 +21,13 @@ import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
 import org.ureca.pinggubackend.domain.recruit.dto.response.ApplyResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.domain.recruit.enums.RecruitStatus;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepositoryCustom;
 import org.ureca.pinggubackend.global.exception.recruit.RecruitException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -83,7 +87,7 @@ public class RecruitServiceImpl implements RecruitService {
             throw RecruitException.of(FORBIDDEN_RECRUIT_ACCESS);
         }
 
-        recruitRepository.deleteById(recruitId);
+        recruit.closeRecruit();
     }
 
     @Override
@@ -114,6 +118,56 @@ public class RecruitServiceImpl implements RecruitService {
         return new ApplyResponse(memberId, recruitId);
     }
 
+    @Override
+    public List<MyRecruitResponse> getRecruitListByMemberId(Long memberId) {
+        List<Recruit> recruits = recruitRepository.findByMemberId(memberId);
+
+        return recruits.stream()
+                .map(recruit -> MyRecruitResponse.from(recruit))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 매일 자정에 실행되는 스케줄 메소드
+     * 경기 날짜가 지난 모집 글들의 상태를 EXPIRED로 변경
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    @Transactional
+    public void expireOutdatedRecruits() {
+        LocalDate today = LocalDate.now();
+
+        // 상태가 OPEN, FULL 이면서 date가 오늘보다 이전인 모집글들 조회
+        List<Recruit> outdatedRecruits = recruitRepository.findByStatusInAndDateBefore(
+                List.of(RecruitStatus.OPEN, RecruitStatus.FULL), today);
+
+        // 모든 만료된 모집글의 상태 변경
+        for (Recruit recruit : outdatedRecruits) {
+            recruit.expireRecruit();
+        }
+
+        // 변경사항 저장 (JPA dirty checking으로 자동 반영될 수도 있음)
+        recruitRepository.saveAll(outdatedRecruits);
+    }
+
+    /**
+     * 매일 자정에 실행되는 스케줄 메소드
+     * 30일 이상 소프트 딜리트된(status가 false이고 deleteDate가 30일 이상 지난) 모집글들을 영구 삭제
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    @Transactional
+    public void deleteOldRecruits() {
+        // 30일 전 날짜 계산
+        LocalDate thirtyDaysAgo = LocalDate.from(LocalDateTime.now().minusDays(30));
+
+        // status가 EXPIRED, CLOSED 이고 deleteDate가 30일 이상 지난 모집글들 조회
+        List<Recruit> oldDeletedRecruits = recruitRepository.findByStatusInAndDeleteDateBefore(
+                List.of(RecruitStatus.EXPIRED, RecruitStatus.CLOSED),
+                thirtyDaysAgo);
+
+        // 영구 삭제
+        recruitRepository.deleteAll(oldDeletedRecruits);
+    }
+
     private Recruit mapToRecruit(Member member, RecruitPostDto recruitPostDto) {
         Club club = clubRepository.findById(recruitPostDto.getClubId())
                 .orElseThrow(() -> RecruitException.of(INVALID_CLUB));
@@ -130,7 +184,7 @@ public class RecruitServiceImpl implements RecruitService {
                 .capacity(recruitPostDto.getCapacity())
                 .gender(recruitPostDto.getGender())
                 .club(club)
-                .status(false)
+                .status(RecruitStatus.OPEN)
                 .build();
 
         return recruit;
@@ -157,14 +211,5 @@ public class RecruitServiceImpl implements RecruitService {
                 .build();
 
         return recruitGetDto;
-    }
-
-    @Override
-    public List<MyRecruitResponse> getRecruitListByMemberId(Long memberId) {
-        List<Recruit> recruits = recruitRepository.findByMemberId(memberId);
-
-        return recruits.stream()
-                .map(recruit -> MyRecruitResponse.from(recruit))
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.ureca.pinggubackend.domain.apply.service.ApplyService;
+import org.ureca.pinggubackend.domain.likes.service.LikeService;
 import org.ureca.pinggubackend.domain.location.entity.Club;
 import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
 import org.ureca.pinggubackend.domain.member.entity.Member;
@@ -14,6 +16,7 @@ import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPostDto;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitPutDto;
+import org.ureca.pinggubackend.domain.recruit.dto.response.ApplyResponse;
 import org.ureca.pinggubackend.domain.recruit.dto.response.RecruitPreviewListResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
@@ -35,6 +38,9 @@ public class RecruitServiceImpl implements RecruitService {
     private final RecruitRepository recruitRepository;
     private final MemberRepository memberRepository;
     private final RecruitRepositoryCustom recruitRepositoryCustom;
+
+    private final LikeService likeService;
+    private final ApplyService applyService;
 
     public Long postRecruit(RecruitPostDto recruitPostDto) {
         Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
@@ -89,6 +95,23 @@ public class RecruitServiceImpl implements RecruitService {
             Pageable pageable
     ) {
         return recruitRepositoryCustom.getRecruitPreviewList(date, gu, level, gender,pageable);
+    }
+
+    @Override
+    public boolean toggleLike(Long memberId, Long recruitId) {
+        return likeService.toggleLike(memberId, recruitId);
+    }
+
+    @Override
+    public ApplyResponse cancelApply(Long memberId, Long recruitId) {
+        applyService.cancelApply(memberId, recruitId);
+        return new ApplyResponse(memberId, recruitId);
+    }
+
+    @Override
+    public ApplyResponse proceedApply(Long memberId, Long recruitId) {
+        applyService.proceedApply(memberId, recruitId);
+        return new ApplyResponse(memberId, recruitId);
     }
 
     private Recruit mapToRecruit(Member member, RecruitPostDto recruitPostDto) {

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -120,7 +120,7 @@ public class RecruitServiceImpl implements RecruitService {
 
     @Override
     public List<MyRecruitResponse> getRecruitListByMemberId(Long memberId) {
-        List<Recruit> recruits = recruitRepository.findByMemberId(memberId);
+        List<Recruit> recruits = recruitRepository.findByMemberIdAndDeleteDateIsNull(memberId);
 
         return recruits.stream()
                 .map(recruit -> MyRecruitResponse.from(recruit))

--- a/src/main/resources/db/changelog/2025/05/13-01-changelog.xml
+++ b/src/main/resources/db/changelog/2025/05/13-01-changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1747096753649-1" author="hongjeong-gi">
+        <addUniqueConstraint columnNames="member_id, recruit_id" constraintName="uc_d295aaa75252bcf1dae2228db"
+                             tableName="apply"/>
+    </changeSet>
+    <changeSet id="1747096753649-2" author="hongjeong-gi">
+        <addUniqueConstraint columnNames="member_id, recruit_id" constraintName="uc_ffd308b09250fd697db80571a"
+                             tableName="likes"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/liquibase/changelog/13-01-changelog.xml
+++ b/src/main/resources/db/liquibase/changelog/13-01-changelog.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1747117700105-3" author="hongjeong-gi">
+        <addColumn tableName="recruit">
+            <column name="delete_date" type="DATE"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1747117700105-4" author="hongjeong-gi">
+        <addUniqueConstraint columnNames="member_id, recruit_id" constraintName="uc_d295aaa75252bcf1dae2228db"
+                             tableName="apply"/>
+    </changeSet>
+    <changeSet id="1747117700105-5" author="hongjeong-gi">
+        <addUniqueConstraint columnNames="member_id, recruit_id" constraintName="uc_ffd308b09250fd697db80571a"
+                             tableName="likes"/>
+    </changeSet>
+    <changeSet id="1747117700105-1" author="hongjeong-gi">
+        <dropColumn columnName="status" tableName="recruit"/>
+    </changeSet>
+    <changeSet id="1747117700105-2" author="hongjeong-gi">
+        <addColumn tableName="recruit">
+            <column name="status" type="VARCHAR(255)">
+                <constraints nullable="false" validateNullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1747124841475-1" author="hongjeong-gi">
+        <createIndex indexName="idx_recruit_status_delete_date" tableName="recruit">
+            <column name="status"/>
+            <column name="delete_date"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="1747124841475-2" author="hongjeong-gi">
+        <createIndex indexName="idx_status_date" tableName="recruit">
+            <column name="status"/>
+            <column name="date"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/ureca/pinggubackend/recruit/RecruitServiceImplTest.java
+++ b/src/test/java/org/ureca/pinggubackend/recruit/RecruitServiceImplTest.java
@@ -1,0 +1,200 @@
+package org.ureca.pinggubackend.recruit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+import org.ureca.pinggubackend.domain.location.entity.Club;
+import org.ureca.pinggubackend.domain.location.repository.ClubRepository;
+import org.ureca.pinggubackend.domain.member.entity.Member;
+import org.ureca.pinggubackend.domain.member.enums.Gender;
+import org.ureca.pinggubackend.domain.member.enums.Level;
+import org.ureca.pinggubackend.domain.member.enums.Racket;
+import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
+import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
+import org.ureca.pinggubackend.domain.recruit.enums.RecruitStatus;
+import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
+import org.ureca.pinggubackend.domain.recruit.service.RecruitServiceImpl;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class RecruitServiceImplTest {
+
+    @Autowired
+    private RecruitServiceImpl recruitService;
+
+    @Autowired
+    private RecruitRepository recruitRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    private Member testMember;
+    private Club testClub;
+    private List<Long> createdRecruitIds = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        // 테스트에 필요한 기본 데이터 생성
+        testMember = memberRepository.findById(100L).orElseThrow();
+        testClub = clubRepository.findById(10L).orElseThrow();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 중 생성된 모든 모집글 삭제
+        recruitRepository.deleteAllById(createdRecruitIds);
+        createdRecruitIds.clear();
+    }
+
+    @Test
+    @DisplayName("만료된 모집글 상태 변경 테스트")
+    void expireOutdatedRecruits() {
+        // 1. 테스트 데이터 준비: 과거 날짜의 모집글 생성
+        Recruit outdatedRecruit = createTestRecruit(LocalDate.now().minusDays(1), RecruitStatus.OPEN);
+        Recruit futureRecruit = createTestRecruit(LocalDate.now().plusDays(1), RecruitStatus.OPEN);
+
+        // 2. 스케줄링 메서드 실행
+        recruitService.expireOutdatedRecruits();
+
+        // 3. 결과 확인
+        Recruit updatedOutdatedRecruit = recruitRepository.findById(outdatedRecruit.getId()).orElseThrow();
+        Recruit updatedFutureRecruit = recruitRepository.findById(futureRecruit.getId()).orElseThrow();
+
+        // 4. 검증
+        assertEquals(RecruitStatus.EXPIRED, updatedOutdatedRecruit.getStatus(),
+                "과거 날짜 모집글은 EXPIRED 상태로 변경되어야 함");
+        assertNotNull(updatedOutdatedRecruit.getDeleteDate(),
+                "과거 날짜 모집글은 deleteDate가 설정되어야 함");
+
+        assertEquals(RecruitStatus.OPEN, updatedFutureRecruit.getStatus(),
+                "미래 날짜 모집글은 상태가 변경되지 않아야 함");
+        assertNull(updatedFutureRecruit.getDeleteDate(),
+                "미래 날짜 모집글은 deleteDate가 설정되지 않아야 함");
+    }
+
+    @Test
+    @DisplayName("오래된 모집글 삭제 테스트")
+    void deleteOldRecruits() {
+        // 1. 테스트 데이터 준비
+        // 31일 전에 만료된 모집글 (삭제 대상)
+        Recruit oldExpiredRecruit = createAndExpireRecruit(LocalDate.now().minusDays(31));
+
+        // 20일 전에 만료된 모집글 (삭제 대상 아님)
+        Recruit recentExpiredRecruit = createAndExpireRecruit(LocalDate.now().minusDays(20));
+
+        // 2. 스케줄링 메서드 실행
+        recruitService.deleteOldRecruits();
+
+        // 3. 결과 확인
+        boolean oldRecruitExists = recruitRepository.existsById(oldExpiredRecruit.getId());
+        boolean recentRecruitExists = recruitRepository.existsById(recentExpiredRecruit.getId());
+
+        // 4. 검증
+        assertFalse(oldRecruitExists, "30일 이상 지난 모집글은 삭제되어야 함");
+        assertTrue(recentRecruitExists, "30일 미만 지난 모집글은 삭제되지 않아야 함");
+    }
+
+    @Test
+    @DisplayName("만료 처리 성능 측정")
+    void measureExpirePerformance() {
+        // 1. 대량의 테스트 데이터 생성
+        createBulkTestData(1000); // 테스트 규모에 맞게 조정
+
+        // 2. 성능 측정 시작
+        long startTime = System.currentTimeMillis();
+
+        // 3. 스케줄링 메서드 실행
+        recruitService.expireOutdatedRecruits();
+
+        // 4. 성능 측정 종료
+        long endTime = System.currentTimeMillis();
+        long executionTime = endTime - startTime;
+
+        // 5. 결과 출력
+        System.out.println("만료 처리 실행 시간: " + executionTime + "ms");
+        System.out.println("영향 받은 행 수: " +
+                recruitRepository.countByStatus(RecruitStatus.EXPIRED));
+    }
+
+    // 테스트용 헬퍼 메서드들
+    private Recruit createTestRecruit(LocalDate date, RecruitStatus status) {
+        Recruit recruit = Recruit.builder()
+                .member(testMember)
+                .club(testClub)
+                .date(date)
+                .status(status)
+                .capacity(4)
+                .current(0)
+                .gender(Gender.ALL)
+                .level(Level.BEGINNER)
+                .racket(Racket.PEN_HOLDER)
+                .title("테스트 모집글 " + UUID.randomUUID())
+                .document("테스트 내용")
+                .chatUrl("https://chat.url")
+                .build();
+
+        Recruit savedRecruit = recruitRepository.save(recruit);
+        createdRecruitIds.add(savedRecruit.getId()); // 나중에 정리할 수 있도록 ID 저장
+        return savedRecruit;
+    }
+
+    private Recruit createAndExpireRecruit(LocalDate deleteDate) {
+        // 1. 기본 모집글 생성
+        Recruit recruit = createTestRecruit(LocalDate.now().minusDays(40), RecruitStatus.OPEN);
+
+        // 2. 상태를 EXPIRED로 변경하고 deleteDate 설정
+        recruit.expireRecruit(); // 이 메서드가 status를 EXPIRED로 설정하고 현재 시간으로 deleteDate 설정
+
+        // 3. deleteDate를 테스트용으로 지정된 날짜로 변경 (리플렉션 사용)
+        // 참고: 실제 테스트에서는 JPA Repository에 맞는 방식으로 조정 필요
+        ReflectionTestUtils.setField(recruit, "deleteDate", deleteDate.atStartOfDay().toLocalDate());
+
+        return recruitRepository.save(recruit);
+    }
+
+    private void createBulkTestData(int count) {
+        List<Recruit> recruits = new ArrayList<>();
+
+        // 과거 날짜의 OPEN 상태 모집글 생성
+        for (int i = 0; i < count; i++) {
+            Recruit recruit = Recruit.builder()
+                    .member(testMember)
+                    .club(testClub)
+                    .date(LocalDate.now().minusDays(i % 30 + 1)) // 1~30일 전 날짜
+                    .status(RecruitStatus.OPEN)
+                    .capacity(4)
+                    .current(0)
+                    .gender(Gender.ALL)
+                    .level(Level.BEGINNER)
+                    .racket(Racket.PEN_HOLDER)
+                    .title("테스트 모집글 " + i)
+                    .document("테스트 내용")
+                    .chatUrl("https://chat.url")
+                    .build();
+
+            recruits.add(recruit);
+        }
+
+        List<Recruit> savedRecruits = recruitRepository.saveAll(recruits);
+
+        // 생성된 모든 모집글의 ID 저장 (나중에 정리하기 위함)
+        savedRecruits.forEach(recruit -> createdRecruitIds.add(recruit.getId()));
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#29 

## 📝 요약(Summary)
- 좋아요 및 신청 기능의 API 엔드포인트 추가 (/recruit/{recruitId}/like, /recruit/{recruitId}/apply, /recruit/{recruitId}/apply DELETE).
- 소프트 딜리트 구현 및 30일 후 영구 삭제를 위한 스케줄링 로직 추가 (expireOutdatedRecruits, deleteOldRecruits).
- Recruit 엔터티의 status 타입을 Boolean에서 RecruitStatus 열거형으로 변경하고, 관련 DTO 및 응답 수정.
- Liquibase를 사용한 DB 스키마 변경 (유니크 제약 조건 추가, delete_date 컬럼 추가, 인덱스 생성).

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 문서 수정

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f3e6a893-d9bc-4a42-88bb-60ee38430e9d)

- 인덱스 처리 없었을 때 만료 처리 실행 시간: 230ms
- 인덱스 처리가 있을 때 만료 처리 실행 시간: 132ms


## 💬 공유사항 to 리뷰어

- 좋아요/신청 API: RecruitController에 추가된 엔드포인트(/like, /apply, /apply DELETE)가 현재 임시로 memberId를 쿼리 파라미터로 받습니다. JWT 인증 구현 후 @RequestParam을 제거하고 사용자 정보를 세션에서 가져오도록 수정 예정입니다. 이 부분의 설계가 적절한지 의견 부탁드립니다.
- RecruitStatus 열거형: Recruit의 status를 Boolean에서 RecruitStatus (OPEN, FULL, CLOSED, EXPIRED)로 변경하며 상태 관리의 명확성을 높였습니다. 추가적인 상태(예: PENDING 등)가 필요할지 논의하고 싶습니다.
- 스케줄링 성능: expireOutdatedRecruits와 deleteOldRecruits는 매일 자정 실행되며, 대량 데이터 처리 시 성능 영향을 최소화하기 위해 인덱스(idx_status_date, idx_recruit_status_delete_date)를 추가했습니다. 테스트 코드에서 1000개 데이터로 성능을 측정했으나, 실제 운영 환경에서의 부하를 고려해 추가 최적화가 필요할지 리뷰 부탁드립니다.
- Liquibase 체인지 로그: delete_date 컬럼 추가와 유니크 제약 조건을 적용했으며, status 컬럼을 드롭 후 재생성했습니다. DB 마이그레이션 과정에서 데이터 무결성을 유지했는지 확인 부탁드립니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
