### PR TITLE
feature: Security.ContextHolder를 활용한 접근 로직 수정

### DIFF
--- a/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyService.java
@@ -1,5 +1,6 @@
 package org.ureca.pinggubackend.domain.apply.service;
 
+import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
 
 import java.util.List;
@@ -7,5 +8,5 @@ import java.util.List;
 public interface ApplyService {
     List<MyApplyResponse> getMyApplies(Long memberId);
     void cancelApply(Long memberId, Long recruitId);
-    void proceedApply(Long memberId, Long recruitId);
+    void proceedApply(Member member, Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/apply/service/ApplyServiceImpl.java
@@ -16,7 +16,6 @@ import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
 import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.RECRUIT_NOT_FOUND;
 
 @Service
@@ -49,9 +48,7 @@ public class ApplyServiceImpl implements ApplyService{
 
     @Override
     @Transactional
-    public void proceedApply(Long memberId, Long recruitId) {
-        //TODO : 사용자 정보 있을 경우, memberId 수정
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> BaseException.of(USER_NOT_FOUND));
+    public void proceedApply(Member member, Long recruitId) {
         Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(() -> BaseException.of(RECRUIT_NOT_FOUND));
 
         Apply apply = new Apply(member, recruit);

--- a/src/main/java/org/ureca/pinggubackend/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/auth/jwt/JwtFilter.java
@@ -28,7 +28,7 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String uri = request.getRequestURI();
 
-        List<String> whitelist = List.of("/auth/kakao-login", "/auth/signup", "/auth/token");
+        List<String> whitelist = List.of("/auth/kakao-login", "/auth/signup", "/auth/token", "/recruit"); //TODO : /recruit 임시 허용
         if (whitelist.stream().anyMatch(uri::startsWith)) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeService.java
@@ -1,10 +1,11 @@
 package org.ureca.pinggubackend.domain.likes.service;
 
+import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
 
 import java.util.List;
 
 public interface LikeService {
     List<MyLikeResponse> getLikedRecruitList(Long memberId);
-    boolean toggleLike(Long memberId, Long recruitId);
+    boolean toggleLike(Member member, Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/likes/service/LikeServiceImpl.java
@@ -10,14 +10,12 @@ import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
 import org.ureca.pinggubackend.domain.recruit.entity.Recruit;
 import org.ureca.pinggubackend.domain.recruit.repository.RecruitRepository;
-import org.ureca.pinggubackend.global.exception.BaseException;
 import org.ureca.pinggubackend.global.exception.recruit.RecruitException;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.ureca.pinggubackend.global.exception.common.CommonErrorCode.USER_NOT_FOUND;
 import static org.ureca.pinggubackend.global.exception.recruit.RecruitErrorCode.RECRUIT_NOT_FOUND;
 
 @Service
@@ -39,15 +37,14 @@ public class LikeServiceImpl implements LikeService {
 
     @Override
     @Transactional
-    public boolean toggleLike(Long recruitId, Long memberId) {
+    public boolean toggleLike(Member member, Long recruitId) {
         // 기존 좋아요 확인
-        Optional<Likes> existingLike = likeRepository.findByMemberIdAndRecruitId(memberId, recruitId);
+        Optional<Likes> existingLike = likeRepository.findByMemberIdAndRecruitId(member.getId(), recruitId);
 
         if (existingLike.isPresent()) {
             likeRepository.delete(existingLike.get());
             return false;
         } else {
-            Member member = memberRepository.findById(memberId).orElseThrow(() -> BaseException.of(USER_NOT_FOUND));
             Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(() -> RecruitException.of(RECRUIT_NOT_FOUND));
 
             Likes like = new Likes(member, recruit);

--- a/src/main/java/org/ureca/pinggubackend/domain/member/entity/Member.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/entity/Member.java
@@ -24,12 +24,15 @@ import java.util.List;
 @Getter
 public class Member extends BaseEntity {
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Likes> likesList = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Apply> applies = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Recruit> recruitList = new ArrayList<>();
 

--- a/src/main/java/org/ureca/pinggubackend/domain/member/service/MemberService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/service/MemberService.java
@@ -9,9 +9,9 @@ import org.ureca.pinggubackend.domain.member.enums.Racket;
 import java.util.Optional;
 
 public interface MemberService {
-    void deleteMember(long memberId);
+    void deleteMember(Member member);
 
-    void updateBasicInfo(long memberId, String name, Gender gender, MainHand mainHand,
+    void updateBasicInfo(Long memberId, String name, Gender gender, MainHand mainHand,
                          Racket racket, String gu, Level level);
 
     Member findById(long memberId);

--- a/src/main/java/org/ureca/pinggubackend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/service/MemberServiceImpl.java
@@ -21,15 +21,12 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void deleteMember(long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> BaseException.of(CommonErrorCode.USER_NOT_FOUND));
-
+    public void deleteMember(Member member) {
         memberRepository.delete(member);
     }
 
     @Override
-    public void updateBasicInfo(long memberId, String name, Gender gender, MainHand mainHand,
+    public void updateBasicInfo(Long memberId, String name, Gender gender, MainHand mainHand,
                                 Racket racket, String gu, Level level) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> BaseException.of(CommonErrorCode.USER_NOT_FOUND));

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
@@ -2,7 +2,9 @@ package org.ureca.pinggubackend.domain.mypage.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.ureca.pinggubackend.domain.member.dto.CustomMemberDetails;
 import org.ureca.pinggubackend.domain.mypage.dto.request.MyPageUpdateRequest;
 import org.ureca.pinggubackend.domain.mypage.dto.response.*;
 import org.ureca.pinggubackend.domain.mypage.service.MyPageService;
@@ -18,49 +20,49 @@ public class MyPageController {
 
     @GetMapping
     public ResponseEntity<MyPageResponse> getMyPage(
-            @RequestParam long memberId // TODO - JWT 구현 이후 변경 예정
-    ){
-        return ResponseEntity.ok(myPageService.getMyPage(memberId));
+            @AuthenticationPrincipal CustomMemberDetails member
+            ){
+        return ResponseEntity.ok(myPageService.getMyPage(member.getMember()));
     }
 
     @PutMapping("/profile")
     public ResponseEntity<MyPageUpdateResponse> editProfile(
-            @RequestParam long memberId, // TODO - JWT 구현 이후 변경 예정
+            @AuthenticationPrincipal CustomMemberDetails principal,
             @RequestBody MyPageUpdateRequest request
     ){
-        return ResponseEntity.ok(myPageService.editProfile(memberId,request));
+        return ResponseEntity.ok(myPageService.editProfile(principal.getMember(), request));
     }
 
     @DeleteMapping
     public ResponseEntity<MyPageDeleteResponse> deleteMember(
-            @RequestParam long memberId // TODO - JWT 구현 이후 변경 예정
+            @AuthenticationPrincipal CustomMemberDetails principal
     ){
-        return ResponseEntity.ok(myPageService.deleteMember(memberId));
+        return ResponseEntity.ok(myPageService.deleteMember(principal.getMember()));
     }
 
     @GetMapping("/applies")
-    public ResponseEntity<List<MyApplyResponse>> getMyApplies(@RequestParam Long memberId) {
-        List<MyApplyResponse> response = myPageService.getMyApplies(memberId);
+    public ResponseEntity<List<MyApplyResponse>> getMyApplies(@AuthenticationPrincipal CustomMemberDetails principal) {
+        List<MyApplyResponse> response = myPageService.getMyApplies(principal.getMember().getId());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/likes")
-    public ResponseEntity<List<MyLikeResponse>> getMyLikes(@RequestParam Long memberId) {
-        List<MyLikeResponse> response = myPageService.getMyLikes(memberId);
+    public ResponseEntity<List<MyLikeResponse>> getMyLikes(@AuthenticationPrincipal CustomMemberDetails principal) {
+        List<MyLikeResponse> response = myPageService.getMyLikes(principal.getMember().getId());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/recruits")
-    public ResponseEntity<List<MyRecruitResponse>> getMyRecruits(@RequestParam Long memberId) {
-        List<MyRecruitResponse> response = myPageService.getMyRecruits(memberId);
+    public ResponseEntity<List<MyRecruitResponse>> getMyRecruits(@AuthenticationPrincipal CustomMemberDetails principal) {
+        List<MyRecruitResponse> response = myPageService.getMyRecruits(principal.getMember().getId());
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/applies")
     public ResponseEntity<MyPageCancelResponse> cancelApply(
-            @RequestParam long memberId, // TODO - JWT 구현 이후 변경 예정
-            @RequestParam long recruitId
+            @AuthenticationPrincipal CustomMemberDetails principal,
+            @RequestParam Long recruitId
     ){
-        return ResponseEntity.ok(myPageService.cancelApply(memberId,recruitId));
+        return ResponseEntity.ok(myPageService.cancelApply(principal.getMember().getId(), recruitId));
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageService.java
@@ -1,14 +1,15 @@
 package org.ureca.pinggubackend.domain.mypage.service;
 
+import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.mypage.dto.request.MyPageUpdateRequest;
 import org.ureca.pinggubackend.domain.mypage.dto.response.*;
 
 import java.util.List;
 
 public interface MyPageService {
-    MyPageResponse getMyPage(long memberId);
-    MyPageUpdateResponse editProfile(long id, MyPageUpdateRequest request);
-    MyPageDeleteResponse deleteMember(long memberId);
+    MyPageResponse getMyPage(Member member);
+    MyPageUpdateResponse editProfile(Member member, MyPageUpdateRequest request);
+    MyPageDeleteResponse deleteMember(Member member);
     MyPageCancelResponse cancelApply(Long memberId, Long recruitId);
     List<MyApplyResponse> getMyApplies(Long memberId);
     List<MyLikeResponse> getMyLikes(Long memberId);

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageServiceImpl.java
@@ -3,22 +3,13 @@ package org.ureca.pinggubackend.domain.mypage.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.ureca.pinggubackend.domain.apply.service.ApplyService;
+import org.ureca.pinggubackend.domain.likes.service.LikeService;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
 import org.ureca.pinggubackend.domain.member.service.MemberService;
-import org.ureca.pinggubackend.domain.member.service.MemberServiceImpl;
 import org.ureca.pinggubackend.domain.mypage.dto.request.MyPageUpdateRequest;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyPageCancelResponse;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyPageDeleteResponse;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyPageUpdateResponse;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyPageResponse;
-import org.ureca.pinggubackend.global.exception.BaseException;
-import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
-import org.ureca.pinggubackend.domain.apply.service.ApplyService;
-import org.ureca.pinggubackend.domain.likes.service.LikeService;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyApplyResponse;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyLikeResponse;
-import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
+import org.ureca.pinggubackend.domain.mypage.dto.response.*;
 import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
 
 import java.util.List;
@@ -34,19 +25,13 @@ public class MyPageServiceImpl implements MyPageService {
     private final MemberService memberService;
 
     @Override
-    public MyPageResponse getMyPage(long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> BaseException.of(CommonErrorCode.USER_NOT_FOUND));
-
+    public MyPageResponse getMyPage(Member member) {
         return MyPageResponse.from(member);
     }
 
     @Override
     @Transactional
-    public MyPageUpdateResponse editProfile(long id, MyPageUpdateRequest request) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(()->BaseException.of(CommonErrorCode.USER_NOT_FOUND));
-
+    public MyPageUpdateResponse editProfile(Member member, MyPageUpdateRequest request) {
         member.updateProfile(
                 request.getName(),
                 request.getGender(),
@@ -55,20 +40,19 @@ public class MyPageServiceImpl implements MyPageService {
                 request.getMainHand(),
                 request.getRacket()
         );
-
         return new MyPageUpdateResponse(member.getId());
     }
 
     @Override
-    public MyPageDeleteResponse deleteMember(long memberId) {
-        memberService.deleteMember(memberId);
-        return new MyPageDeleteResponse(memberId);
+    public MyPageDeleteResponse deleteMember(Member member) {
+        memberService.deleteMember(member);
+        return new MyPageDeleteResponse(member.getId());
     }
 
     @Override
     public MyPageCancelResponse cancelApply(Long memberId, Long recruitId) {
-        applyService.cancelApply(memberId,recruitId);
-        return new MyPageCancelResponse(memberId,recruitId);
+        applyService.cancelApply(memberId, recruitId);
+        return new MyPageCancelResponse(memberId, recruitId);
     }
 
     @Override

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/controller/RecruitController.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.ureca.pinggubackend.domain.member.dto.CustomMemberDetails;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.recruit.dto.request.RecruitGetDto;
@@ -42,9 +44,9 @@ public class RecruitController {
     }
 
     @PostMapping("")
-    public ResponseEntity<Void> postRecruit(@RequestBody @Valid RecruitPostDto recruitPostDto) {
-        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
-        Long recruitId = recruitService.postRecruit(recruitPostDto);
+    public ResponseEntity<Void> postRecruit(@AuthenticationPrincipal CustomMemberDetails principal,
+                                            @RequestBody @Valid RecruitPostDto recruitPostDto) {
+        Long recruitId = recruitService.postRecruit(principal.getMember(), recruitPostDto);
         URI uri = URI.create("/recruit/" + recruitId);
         return ResponseEntity.created(uri).build();
     }
@@ -56,37 +58,35 @@ public class RecruitController {
     }
 
     @PutMapping("/{recruitId}")
-    public ResponseEntity<Void> putRecruit(@PathVariable Long recruitId, @RequestBody @Valid RecruitPutDto recruitPutDto) {
-        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
-        recruitService.putRecruit(recruitId, recruitPutDto);
+    public ResponseEntity<Void> putRecruit(@PathVariable Long recruitId,
+                                           @AuthenticationPrincipal CustomMemberDetails principal,
+                                           @RequestBody @Valid RecruitPutDto recruitPutDto) {
+        recruitService.putRecruit(principal.getMember().getId(), recruitId, recruitPutDto);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{recruitId}")
-    public ResponseEntity<Void> deleteMapping(@PathVariable Long recruitId) {
-        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
-        recruitService.deleteRecruit(recruitId);
+    public ResponseEntity<Void> deleteMapping(@AuthenticationPrincipal CustomMemberDetails principal,
+                                              @PathVariable Long recruitId) {
+        recruitService.deleteRecruit(principal.getMember().getId(), recruitId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{recruitId}/like")
-    public ResponseEntity<Boolean> toggleLike(@PathVariable Long recruitId, @RequestParam Long memberId) {
-        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
-        boolean isLiked = recruitService.toggleLike(memberId, recruitId);
+    public ResponseEntity<Boolean> toggleLike(@AuthenticationPrincipal CustomMemberDetails principal, @PathVariable Long recruitId) {
+        boolean isLiked = recruitService.toggleLike(principal.getMember(), recruitId);
         return ResponseEntity.ok(isLiked);
     }
 
     @PostMapping("/{recruitId}/apply")
-    public ResponseEntity<ApplyResponse> proceedApply(@PathVariable Long recruitId, @RequestParam Long memberId) {
-        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
-        return ResponseEntity.ok(recruitService.proceedApply(memberId, recruitId));
+    public ResponseEntity<ApplyResponse> proceedApply(@AuthenticationPrincipal CustomMemberDetails principal, @PathVariable Long recruitId) {
+        return ResponseEntity.ok(recruitService.proceedApply(principal.getMember(), recruitId));
     }
 
     @DeleteMapping("/{recruitId}/apply")
-    public ResponseEntity<ApplyResponse> cancelApply(@PathVariable Long recruitId,
-                                               @RequestParam Long memberId
+    public ResponseEntity<ApplyResponse> cancelApply(@AuthenticationPrincipal CustomMemberDetails principal,
+                                                     @PathVariable Long recruitId
     ) {
-        // ToDo: 로그인 개발 완료 되면 유저 정보 가져오기
-        return ResponseEntity.ok(recruitService.cancelApply(memberId, recruitId));
+        return ResponseEntity.ok(recruitService.cancelApply(principal.getMember().getId(), recruitId));
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitService.java
@@ -2,6 +2,7 @@ package org.ureca.pinggubackend.domain.recruit.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.member.enums.Gender;
 import org.ureca.pinggubackend.domain.member.enums.Level;
 import org.ureca.pinggubackend.domain.mypage.dto.response.MyRecruitResponse;
@@ -16,13 +17,13 @@ import java.util.List;
 
 public interface RecruitService {
 
-    Long postRecruit(RecruitPostDto recruitPostDto);
+    Long postRecruit(Member member, RecruitPostDto recruitPostDto);
     List<MyRecruitResponse> getRecruitListByMemberId(Long memberId);
     RecruitGetDto getRecruit(Long recruitId);
-    void putRecruit(Long recruitId, RecruitPutDto recruitPutDto);
-    void deleteRecruit(Long recruitId);
+    void putRecruit(Long memberId, Long recruitId, RecruitPutDto recruitPutDto);
+    void deleteRecruit(Long memberId, Long recruitId);
     Page<RecruitPreviewListResponse> getRecruitPreviewList(LocalDate date, String gu, Level level, Gender gender, Pageable pageable);
-    boolean toggleLike(Long memberId, Long recruitId);
-    ApplyResponse proceedApply(Long memberId, Long recruitId);
+    boolean toggleLike(Member member, Long recruitId);
+    ApplyResponse proceedApply(Member member, Long recruitId);
     ApplyResponse cancelApply(Long memberId, Long recruitId);
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/recruit/service/RecruitServiceImpl.java
@@ -46,9 +46,8 @@ public class RecruitServiceImpl implements RecruitService {
     private final LikeService likeService;
     private final ApplyService applyService;
 
-    public Long postRecruit(RecruitPostDto recruitPostDto) {
-        Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
-
+    @Override
+    public Long postRecruit(Member member, RecruitPostDto recruitPostDto) {
         Recruit recruit = mapToRecruit(member, recruitPostDto);
         recruitRepository.save(recruit);
         return recruit.getId();
@@ -60,13 +59,11 @@ public class RecruitServiceImpl implements RecruitService {
         return mapToRecruitDto(recruit);
     }
 
-    public void putRecruit(Long recruitId, RecruitPutDto recruitPutDto) {
+    public void putRecruit(Long memberId, Long recruitId, RecruitPutDto recruitPutDto) {
         Recruit recruit = recruitRepository.findById(recruitId)
                 .orElseThrow(() -> RecruitException.of(RECRUIT_NOT_FOUND));
 
-        // 글을 작성한 유저가 아니라면 예외 발생
-        Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
-        if (!Objects.equals(recruit.getMember().getId(), member.getId())) {
+        if (!Objects.equals(recruit.getMember().getId(), memberId)) {
             throw RecruitException.of(FORBIDDEN_RECRUIT_ACCESS);
         }
 
@@ -77,13 +74,11 @@ public class RecruitServiceImpl implements RecruitService {
         recruitRepository.save(recruit);
     }
 
-    public void deleteRecruit(Long recruitId) {
+    public void deleteRecruit(Long memberId, Long recruitId) {
         Recruit recruit = recruitRepository.findById(recruitId)
                 .orElseThrow(() -> RecruitException.of(RECRUIT_NOT_FOUND));
 
-        // 글을 작성한 유저가 아니라면 예외 발생
-        Member member = memberRepository.findById(1L).get(); // 로그인 개발전까지 임시로 사용합니다.
-        if (!Objects.equals(recruit.getMember().getId(), member.getId())) {
+        if (!Objects.equals(recruit.getMember().getId(), memberId)) {
             throw RecruitException.of(FORBIDDEN_RECRUIT_ACCESS);
         }
 
@@ -102,8 +97,8 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     @Override
-    public boolean toggleLike(Long memberId, Long recruitId) {
-        return likeService.toggleLike(memberId, recruitId);
+    public boolean toggleLike(Member member, Long recruitId) {
+        return likeService.toggleLike(member, recruitId);
     }
 
     @Override
@@ -113,9 +108,9 @@ public class RecruitServiceImpl implements RecruitService {
     }
 
     @Override
-    public ApplyResponse proceedApply(Long memberId, Long recruitId) {
-        applyService.proceedApply(memberId, recruitId);
-        return new ApplyResponse(memberId, recruitId);
+    public ApplyResponse proceedApply(Member member, Long recruitId) {
+        applyService.proceedApply(member, recruitId);
+        return new ApplyResponse(member.getId(), recruitId);
     }
 
     @Override


### PR DESCRIPTION
# PR Template

## #️⃣ Issue Number

#35

## 📝 요약(Summary)

이 PR은 기존 코드에서 `memberId` (`Long`)를 직접 사용하던 부분을 `Member` 엔티티 객체로 대체하여 타입 안정성을 높이고, JWT 기반 인증(`CustomMemberDetails`)을 활용하도록 리팩토링한 변경사항을 포함합니다. 또한, `recruit` 엔드포인트를 임시로 화이트리스트에 추가하여 인증 없이 접근 가능하도록 수정했습니다. 주요 변경 목적은 코드의 가독성, 유지보수성, 그리고 인증된 사용자 정보를 보다 효과적으로 활용하기 위함입니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 코드 리팩토링

## 📸 스크린샷 (선택)

(해당 PR은 코드 리팩토링 중심이므로 스크린샷 없음)

## 💬 공유사항 to 리뷰어

- `Member` 객체를 직접 전달하도록 수정하면서, 불필요한 `memberRepository.findById` 호출을 제거하여 성능을 최적화했습니다. 이 부분에서 추가적인 최적화가 가능한지 의견 부탁드립니다.
- `JwtFilter`에서 `/recruit` 엔드포인트를 임시로 화이트리스트에 추가했는데, 이는 개발 중 테스트를 위한 조치입니다. 추후 인증이 완료되면 제거 예정입니다. 이 접근 방식에 대한 의견이 있으면 공유 부탁드립니다.
- `RecruitService` 및 `MyPageController`에서 `AuthenticationPrincipal`을 활용하여 인증된 사용자 정보를 바로 가져오도록 했습니다. 이 방식이 현재 구조에 적합한지, 또는 다른 인증 처리 방식이 더 나을지 논의하고 싶습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분