### PR TITLE
[Feature] 프로필사진 S3 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// aws
+	implementation 'software.amazon.awssdk:s3:2.25.20'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ureca/pinggubackend/domain/auth/Controller/AuthController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/auth/Controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import org.ureca.pinggubackend.domain.auth.dto.*;
 import org.ureca.pinggubackend.domain.auth.service.AuthService;
 
+import java.io.IOException;
 import java.time.Duration;
 
 @RestController
@@ -19,7 +20,7 @@ public class AuthController {
     private final AuthService authService;
     
     @GetMapping("/kakao-login")
-    public ResponseEntity<KakaoLoginResponse> kakaoLogin(@RequestParam("code") String code) {
+    public ResponseEntity<KakaoLoginResponse> kakaoLogin(@RequestParam("code") String code) throws IOException {
         return ResponseEntity.ok(kakaoOAuthService.loginOrRegister(code));
     }
 

--- a/src/main/java/org/ureca/pinggubackend/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/auth/jwt/JwtFilter.java
@@ -28,7 +28,7 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String uri = request.getRequestURI();
 
-        List<String> whitelist = List.of("/auth/kakao-login", "/auth/signup", "/auth/token", "/recruit"); //TODO : /recruit 임시 허용
+        List<String> whitelist = List.of("/auth/kakao-login", "/auth/signup", "/auth/token", "/recruit", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**"); //TODO : /recruit 임시 허용
         if (whitelist.stream().anyMatch(uri::startsWith)) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/org/ureca/pinggubackend/domain/auth/service/AuthService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/auth/service/AuthService.java
@@ -15,9 +15,11 @@ import org.ureca.pinggubackend.domain.member.enums.MainHand;
 import org.ureca.pinggubackend.domain.member.enums.Racket;
 import org.ureca.pinggubackend.domain.member.repository.MemberRepository;
 import org.ureca.pinggubackend.domain.member.service.MemberService;
+import org.ureca.pinggubackend.domain.mypage.service.S3Service;
 import org.ureca.pinggubackend.global.exception.BaseException;
 import org.ureca.pinggubackend.global.exception.common.CommonErrorCode;
 
+import java.io.IOException;
 import java.util.Optional;
 
 @Service
@@ -29,6 +31,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final KakaoProfileApi kakaoProfileApi;
     private final KakaoTokenApi kakaoTokenApi;
+    private final S3Service s3Service;
 
     private String getKakaoAccessToken(String code) {
         return kakaoTokenApi.requestAccessToken(code);
@@ -47,7 +50,7 @@ public class AuthService {
                 );
     }
 
-    public KakaoLoginResponse loginOrRegister(String code) {
+    public KakaoLoginResponse loginOrRegister(String code) throws IOException {
         KakaoUserProfileResponse kakaoUserProfile = getUserProfileFromKakao(code);
 
         Long kakaoId = kakaoUserProfile.getId();
@@ -70,6 +73,9 @@ public class AuthService {
             String tmpName = kakaoUserProfile.getKakaoAccount().getProfile().getNickname();
             String tmpEmail = kakaoUserProfile.getKakaoAccount().getEmail();
 
+            String profileImgUrl = kakaoUserProfile.getKakaoAccount().getProfile().getProfileImageUrl();
+            String s3Url = s3Service.uploadImageFromUrl(profileImgUrl);
+
             Member newMember = Member.builder()
                     .kakaoId(kakaoId)
                     .email(tmpEmail)
@@ -80,6 +86,7 @@ public class AuthService {
                     .level(Level.BEGINNER)
                     .mainHand(MainHand.L)
                     .racket(Racket.PEN_HOLDER)
+                    .profileImgUrl(s3Url)
                     .build();
 
             Long tmpMemberId = memberRepository.save(newMember).getId();

--- a/src/main/java/org/ureca/pinggubackend/domain/member/entity/Member.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/entity/Member.java
@@ -51,6 +51,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String gu;
 
+//    @Column(nullable = false)
+    private String profileImgUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;

--- a/src/main/java/org/ureca/pinggubackend/domain/member/entity/Member.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/member/entity/Member.java
@@ -85,4 +85,8 @@ public class Member extends BaseEntity {
         this.mainHand = mainHand;
         this.racket = racket;
     }
+
+    public void updateProfileImg(String url) {
+        this.profileImgUrl = url;
+    }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/controller/MyPageController.java
@@ -1,14 +1,17 @@
 package org.ureca.pinggubackend.domain.mypage.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.ureca.pinggubackend.domain.member.dto.CustomMemberDetails;
 import org.ureca.pinggubackend.domain.mypage.dto.request.MyPageUpdateRequest;
 import org.ureca.pinggubackend.domain.mypage.dto.response.*;
 import org.ureca.pinggubackend.domain.mypage.service.MyPageService;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -31,6 +34,14 @@ public class MyPageController {
             @RequestBody MyPageUpdateRequest request
     ){
         return ResponseEntity.ok(myPageService.editProfile(principal.getMember(), request));
+    }
+
+    @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> changeProfileImg(
+            @AuthenticationPrincipal CustomMemberDetails principal,
+            @RequestParam MultipartFile file
+    ) throws IOException {
+        return ResponseEntity.ok(myPageService.changeProfileImg(principal.getMember(), file));
     }
 
     @DeleteMapping

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyPageResponse.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/dto/response/MyPageResponse.java
@@ -12,6 +12,7 @@ public class MyPageResponse {
     private final String level;
     private final String mainHand;
     private final String racket;
+    private final String profileImgUrl;
 
     public static MyPageResponse from(Member member) {
         return new MyPageResponse(
@@ -20,7 +21,8 @@ public class MyPageResponse {
                 member.getGu(),
                 member.getLevel().toString(),
                 member.getMainHand().toString(),
-                member.getRacket().toString()
+                member.getRacket().toString(),
+                member.getProfileImgUrl()
         );
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageService.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageService.java
@@ -1,9 +1,11 @@
 package org.ureca.pinggubackend.domain.mypage.service;
 
+import org.springframework.web.multipart.MultipartFile;
 import org.ureca.pinggubackend.domain.member.entity.Member;
 import org.ureca.pinggubackend.domain.mypage.dto.request.MyPageUpdateRequest;
 import org.ureca.pinggubackend.domain.mypage.dto.response.*;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface MyPageService {
@@ -14,4 +16,5 @@ public interface MyPageService {
     List<MyApplyResponse> getMyApplies(Long memberId);
     List<MyLikeResponse> getMyLikes(Long memberId);
     List<MyRecruitResponse> getMyRecruits(Long memberId);
+    String changeProfileImg(Member member, MultipartFile file) throws IOException;
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/service/MyPageServiceImpl.java
@@ -3,6 +3,7 @@ package org.ureca.pinggubackend.domain.mypage.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.ureca.pinggubackend.domain.apply.service.ApplyService;
 import org.ureca.pinggubackend.domain.likes.service.LikeService;
 import org.ureca.pinggubackend.domain.member.entity.Member;
@@ -12,6 +13,7 @@ import org.ureca.pinggubackend.domain.mypage.dto.request.MyPageUpdateRequest;
 import org.ureca.pinggubackend.domain.mypage.dto.response.*;
 import org.ureca.pinggubackend.domain.recruit.service.RecruitService;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -23,6 +25,7 @@ public class MyPageServiceImpl implements MyPageService {
     private final ApplyService applyService;
     private final LikeService likeService;
     private final MemberService memberService;
+    private final S3Service s3Service;
 
     @Override
     public MyPageResponse getMyPage(Member member) {
@@ -68,5 +71,14 @@ public class MyPageServiceImpl implements MyPageService {
     @Override
     public List<MyRecruitResponse> getMyRecruits(Long memberId) {
         return recruitService.getRecruitListByMemberId(memberId);
+    }
+
+    @Override
+    public String changeProfileImg(Member member, MultipartFile file) throws IOException {
+        String url = s3Service.upload(file);
+        s3Service.deleteImageByUrl(member.getProfileImgUrl()); // 기존 프로필 이미지 삭제
+        member.updateProfileImg(url);
+        memberRepository.save(member);
+        return url;
     }
 }

--- a/src/main/java/org/ureca/pinggubackend/domain/mypage/service/S3Service.java
+++ b/src/main/java/org/ureca/pinggubackend/domain/mypage/service/S3Service.java
@@ -1,0 +1,43 @@
+package org.ureca.pinggubackend.domain.mypage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadImageFromUrl(String imageUrl) throws IOException {
+        // 파일 이름 설정
+        String fileName = UUID.randomUUID() + ".jpg";
+
+        // URL에서 이미지 읽어오기
+        URL url = new URL(imageUrl);
+        try (InputStream inputStream = url.openStream()) {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileName)
+                    .contentType("image/jpeg") // 필요 시 contentType 추론 가능
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, url.openConnection().getContentLength()));
+
+            return "https://%s.s3.us-east-1.amazonaws.com/%s".formatted(bucketName, fileName);
+        }
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/global/config/S3Config.java
+++ b/src/main/java/org/ureca/pinggubackend/global/config/S3Config.java
@@ -1,0 +1,18 @@
+package org.ureca.pinggubackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/org/ureca/pinggubackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/ureca/pinggubackend/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/recruit/**")
+                        .requestMatchers("/auth/**", "/recruit/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**")
                         .permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtFilter(jwtUtil, memberRepository), LogoutFilter.class)

--- a/src/main/java/org/ureca/pinggubackend/global/config/SwaggerConfig.java
+++ b/src/main/java/org/ureca/pinggubackend/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package org.ureca.pinggubackend.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("PingGu API명세서")
+                        .version("v1"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT") // 또는 "Bearer"
+                        ));
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,3 +10,15 @@ spring:
       redirect-uri: ${KAKAO_REDIRECT_URL}
   jwt:
     secret: ${JWT_SECRET_CODE}
+
+cloud:
+  aws:
+    s3:
+      bucket: pinggu-s3
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    region:
+      static: us-east-1
+    stack:
+      auto: false

--- a/src/main/resources/db/liquibase/changelog/15-01-changelog.xml
+++ b/src/main/resources/db/liquibase/changelog/15-01-changelog.xml
@@ -16,5 +16,10 @@
     <changeSet id="1747234861210-3" author="djlim00">
         <addUniqueConstraint columnNames="kakao_id" constraintName="uc_member_kakaoid" tableName="member"/>
     </changeSet>
+    <changeSet id="1747286430103-1" author="locke">
+        <addColumn tableName="member">
+            <column name="profile_img_url" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
## #️⃣ Issue Number

#39 

## 📝 요약(Summary)
1. 회원가입시 유저의 카카오 프로필 사진을 가져와서 핑구의 프사로 등록합니다.
2. 마이페이지에 프로필 사진 변경 기능을 추가합니다. 변경시에는 기존 사진을 삭제하고, 새로운 사진을 업로드합니다.
3. 마이페이지에 접근하면 프로필 사진 URL이 함께 리턴됩니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 15분
