### PR TITLE
fix: 시큐리티 엔드포인트 추가(location)

### DIFF
--- a/src/main/java/org/ureca/pinggubackend/global/config/SecurityConfig.java
+++ b/src/main/java/org/ureca/pinggubackend/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/recruit/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**")
+                        .requestMatchers("/auth/**", "/recruit/**", "/location/", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**")
                         .permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtFilter(jwtUtil, memberRepository), LogoutFilter.class)


### PR DESCRIPTION
## #️⃣ Issue Number
#42 

## 📝 요약(Summary)

회원가입시 기본정보 입력하는 과정에서 지역별 탁구장 정보가 뜨지 않는 문제를 해결하기 위해 SecurityConfig의 엔드포인트를 추가했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7bec05c6-fe4a-4abd-8765-68e305dd8c1d)


## 💬 공유사항 to 리뷰어
SecurityConfig에 엔드포인트 추가했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [z] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 1분
